### PR TITLE
Fixed a bug that stopped builds

### DIFF
--- a/Editor/TileMainEditor.cs
+++ b/Editor/TileMainEditor.cs
@@ -1,7 +1,10 @@
 using UnityEngine;
 using UnityEditor;
+using UnityEditorInternal;
+using System;
+using System.Reflection;
 using System.Collections;
-using System.IO;
+using System.Collections.Generic;
 
 [CustomEditor(typeof(TileMain))]
 public class TileMainEditor : Editor
@@ -39,7 +42,7 @@ public class TileMainEditor : Editor
         tilemain = (TileMain)target;
         tilesize.x = tilemain.PixelSize.x / tilemain.pixeltounit;
         tilesize.y = tilemain.PixelSize.y / tilemain.pixeltounit;
-        sortingLayers = tilemain.GetSortingLayerNames();
+        sortingLayers = GetSortingLayerNames();
         //Debug.Log(tilemain.Tiles[0].textureRect.height / tilemain.Tiles[0].bounds.size.y);
     }
 
@@ -213,6 +216,7 @@ public class TileMainEditor : Editor
 
         }
     }
+
     //Generation function for asset texture from an array of sprites
     public void assetPreviewGenerator()
     {
@@ -361,5 +365,11 @@ public class TileMainEditor : Editor
             Debug.Log("Must select a texture with sprites.");
     }
 
-
+    // Get the sorting layer names
+    public string[] GetSortingLayerNames()
+    {
+        Type internalEditorUtilityType = typeof(InternalEditorUtility);
+        PropertyInfo sortingLayersProperty = internalEditorUtilityType.GetProperty("sortingLayerNames", BindingFlags.Static | BindingFlags.NonPublic);
+        return (string[])sortingLayersProperty.GetValue(null, new object[0]);
+    }
 }

--- a/Editor/TileMainEditor.cs.meta
+++ b/Editor/TileMainEditor.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3619cd52d754e8a4795ea98d0b6ecdf8
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Scripts/TileMain.cs
+++ b/Scripts/TileMain.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEditorInternal;
 using System;
 using System.Reflection;
 using System.Collections;
@@ -94,13 +93,5 @@ public class TileMain : MonoBehaviour
             Gizmos.color = Color.red;
             Gizmos.DrawWireCube(this.MarkerPosition, new Vector3(this.PixelSize.x / pixeltounit, this.PixelSize.y / pixeltounit, 1) * 1.1f);
         }
-    }
-
-    // Get the sorting layer names
-    public string[] GetSortingLayerNames()
-    {
-        Type internalEditorUtilityType = typeof(InternalEditorUtility);
-        PropertyInfo sortingLayersProperty = internalEditorUtilityType.GetProperty("sortingLayerNames", BindingFlags.Static | BindingFlags.NonPublic);
-        return (string[])sortingLayersProperty.GetValue(null, new object[0]);
     }
 }

--- a/Scripts/TileMain.cs.meta
+++ b/Scripts/TileMain.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 465888607f7b96444961f76c15d0d953
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 


### PR DESCRIPTION
Using UnityEditorInternal in a script that is not in an Editor
folder(TileMain.cs), caused errors when building and stopped the builds.

This is because that namespace isn't supposed to be compiled with
builds, the fix is simple, I just moved the method that used it to the
editor script and made appropriate changes.